### PR TITLE
Fix Rotate EP functionality

### DIFF
--- a/server/services/group.js
+++ b/server/services/group.js
@@ -120,8 +120,7 @@ function scheduleEPRotation(group) {
 
 function rotateEscalationPolicy(group) {
   let subscribers = group.escalationPolicy.subscribers;
-  const newFirstUser = subscribers.pop();
-  subscribers.unshift(newFirstUser);
+  subscribers.push(subscribers.shift());
   subscribers = subscribers.map(s => s.toString());
   const groupUpdates = { lastRotated: new Date() };
   return scheduleEPRotation(group)

--- a/server/tests/services/group.test.js
+++ b/server/tests/services/group.test.js
@@ -348,9 +348,9 @@ describe('## Group Service', () => {
         .then((updatedGroup) => {
           const ep = updatedGroup.escalationPolicy;
           expect(ep.subscribers.length).to.eq(subscribers.length);
-          expect(ep.subscribers[0].toString()).to.eq(subscribers[2]);
-          expect(ep.subscribers[1].toString()).to.eq(subscribers[0]);
-          expect(ep.subscribers[2].toString()).to.eq(subscribers[1]);
+          expect(ep.subscribers[0].toString()).to.eq(subscribers[1]);
+          expect(ep.subscribers[1].toString()).to.eq(subscribers[2]);
+          expect(ep.subscribers[2].toString()).to.eq(subscribers[0]);
 
           expect(equalDates(updatedGroup.lastRotated, new Date())).to.eq(true);
 


### PR DESCRIPTION
Rotate EP should take the first user and add it to the end of the array, and now it does