### PR TITLE
Fix bug where group object returned is not current

### DIFF
--- a/server/services/group.js
+++ b/server/services/group.js
@@ -67,13 +67,8 @@ function removeUser(group, userId) {
       const removeGroupFromUser = userService.removeGroupByUserId(validatedUserId, group.name);
       return Promise.all([removeUserFromGroup, removeGroupFromUser]);
     })
-    .then((promiseResults) => {
-      const groupR = promiseResults[0];
-      const removeFromEP = Group.removeUserFromEscalationPolicy(groupR.name, userId);
-      const removeAdminP = removeAdmin(groupR.name, userId);
-      return Promise.all([removeAdminP, removeFromEP]);
-    })
-    .then(results => results[0]);
+    .then(promiseResults => Group.removeUserFromEscalationPolicy(promiseResults[0].name, userId))
+    .then(g => removeAdmin(g.name, userId));
 }
 
 function makeJoinRequest(groupName, userId) {

--- a/server/tests/services/group.test.js
+++ b/server/tests/services/group.test.js
@@ -182,6 +182,24 @@ describe('## Group Service', () => {
           .then(() => done());
       });
 
+      context('when the user is an admin and in the escalation policy', () => {
+        beforeEach((done) => {
+          groupService.addAdmin(group.name, userId)
+            .then(() => done());
+        });
+
+        it('should remove the user from the EP and admin lists', (done) => {
+          groupService.removeUser(group, userId)
+            .then((savedGroup) => {
+              expect(savedGroup.name).to.equal(group.name);
+              expect(savedGroup.users).to.not.include(userId);
+              expect(savedGroup.admins).to.not.include(userId);
+              expect(savedGroup.escalationPolicy.subscribers).to.be.empty;
+              done();
+            });
+        });
+      });
+
       context('when the user exists', () => {
         it('should remove a user from the group by id', (done) => {
           groupService.removeUser(group, userId)


### PR DESCRIPTION
- make remove calls in succession rather than concurrently, in order to
  ensure the most current group is being returned
- add a test for this functionality (where a user is an admin and also
  in the escalation policy and needs to be deleted from both)