### PR TITLE
Fix bug where group search did not search properly

### DIFF
--- a/server/controllers/group.js
+++ b/server/controllers/group.js
@@ -29,7 +29,7 @@ function updateGroup(req, res, next) {
 }
 
 function searchByName(req, res, next) {
-  groupService.searchByName(req.params.groupName)
+  groupService.searchByName(req.params.partialGroupName)
     .then(groups => Group.populate(groups, 'users'))
     .then(groups => res.json(groups))
     .catch(err => next(err));

--- a/server/routes/group.js
+++ b/server/routes/group.js
@@ -10,7 +10,7 @@ const router = express.Router(); // eslint-disable-line new-cap
 router.route('/')
   .post(validate(paramValidation.createGroup), userMiddleware.isSysAdmin, groupCtrl.createGroup);
 
-router.route('/searchByName')
+router.route('/searchByName/:partialGroupName*?')
   .get(groupCtrl.searchByName);
 
 router.route('/:groupName')


### PR DESCRIPTION
- without the request parameter, the searchByName function will simply
  return all groups every time